### PR TITLE
Check if document.readyState === 'complete' before trying onload listeners

### DIFF
--- a/flask_pagedown/widgets.py
+++ b/flask_pagedown/widgets.py
@@ -17,7 +17,9 @@ f = function() {
     textarea.onkeyup = function() { preview.innerHTML = flask_pagedown_converter(textarea.value); }
     textarea.onkeyup.call(textarea);
 }
-if (window.addEventListener)
+if (document.readyState === 'complete') 
+    f();
+else if (window.addEventListener)
     window.addEventListener("load", f, false);
 else if (window.attachEvent)
     window.attachEvent("onload", f);

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='Flask-PageDown',
-    version='0.1.2',
+    version='0.1.3',
     url='http://github.com/miguelgrinberg/flask-pagedown/',
     license='MIT',
     author='Miguel Grinberg',


### PR DESCRIPTION
Add check if the document is already ready, and if so skip the onload handlers. Fixes live loading of markdown forms

Otherwise, continue as normal.

I do a lot of server side form rendering (mainly for CSRF tokens) and loading the forms into the page (lightbox, etc) through jquery.load, and this fixes pagedown in those use cases. Does not cause problems otherwise
