### PR TITLE
Add PageDown extensions

### DIFF
--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -25,7 +25,7 @@
             {{ form.hidden_tag() }}
             <div>
                 <b>{{ form.pagedown.label }}</b>:
-                {{ form.pagedown(rows=10, style='width:100%') }}
+                {{ form.pagedown(rows=10, extensions=['newlines'], style='width:100%') }}
             </div>
             <br>
             <div>

--- a/flask_pagedown/__init__.py
+++ b/flask_pagedown/__init__.py
@@ -5,8 +5,9 @@ from flask import current_app
 class _pagedown(object):
     def include_pagedown(self):
         return Markup('''
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.min.js"></script>
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Sanitizer.min.js"></script>
+<script type="text/javascript" src="https://github.com/jmcmanus/pagedown-extra/raw/master/pagedown/Markdown.Converter.js"></script>
+<script type="text/javascript" src="https://github.com/jmcmanus/pagedown-extra/raw/master/pagedown/Markdown.Sanitizer.js"></script>
+<script type="text/javascript" src="https://github.com/jmcmanus/pagedown-extra/raw/master/Markdown.Extra.js"></script>
 ''')
 
     def html_head(self):

--- a/flask_pagedown/widgets.py
+++ b/flask_pagedown/widgets.py
@@ -3,16 +3,12 @@ from wtforms.widgets import HTMLString, TextArea
 pagedown_pre_html = '<div class="flask-pagedown">'
 pagedown_post_html = '</div>'
 preview_html = '''
-<div class="flask-pagedown-preview" id="flask-pagedown-%(field)s-preview"></div>
+<div class="flask-pagedown-preview" id="flask-pagedown-{field}-preview"></div>
 <script type="text/javascript">
-f = function() {
+f = function() {{
     if (typeof flask_pagedown_converter === "undefined")
         flask_pagedown_converter = Markdown.getSanitizingConverter().makeHtml;
-    var textarea = document.getElementById("flask-pagedown-%(field)s");
-    var preview = document.getElementById("flask-pagedown-%(field)s-preview");
-    textarea.onkeyup = function() { preview.innerHTML = flask_pagedown_converter(textarea.value); }
     textarea.onkeyup.call(textarea);
-}
 if (document.readyState === 'complete')
     f();
 else if (window.addEventListener)
@@ -43,5 +39,4 @@ class PageDown(TextArea):
                 field, id='flask-pagedown-' + field.name,
                 class_=' '.join(class_), **kwargs) + pagedown_post_html
         if show_preview:
-            html += preview_html % {'field': field.name}
         return HTMLString(html)


### PR DESCRIPTION
I added support for jmcmanus’s Pagedown extensions (https://github.com/jmcmanus/pagedown-extra).

Loading time is longer now because I use the raw js files from jmcmanus’s repository instead of static files.
