### PR TITLE
Added optional argument to specify paths to alternate scripts

### DIFF
--- a/flask_pagedown/__init__.py
+++ b/flask_pagedown/__init__.py
@@ -3,11 +3,11 @@ from flask import current_app
 
 
 class _pagedown(object):
-    def include_pagedown(self):
+    def include_pagedown(self, converter_js="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.min.js", sanitizer_js="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Sanitizer.min.js"):
         return Markup('''
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.min.js"></script>
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Sanitizer.min.js"></script>
-''')
+            <script type="text/javascript" src="{}"></script>
+            <script type="text/javascript" src="{}"></script>
+            '''.format(converter_js, sanitizer_js))
 
     def html_head(self):
         return self.include_pagedown()


### PR DESCRIPTION
Added optional argument to specify paths to alternate scripts Markdown.Sanitizer and Markdown.Converter.

If none are specified the cdnjs.cloudflare default is used.

Example usage such as:

```
{{ pagedown.include_pagedown([url_for(".static",filaname="js/md.sanitizer.min.js"),
                              url_for(".static",filename="js/md.converter.min.js")]) }}

```
