### PR TITLE
Add option to pass in Markdown Converter and Sanitizer files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ Finally, the template needs the support Javascript code added, by calling `paged
     </body>
     </html>
 
+        {{ pagedown.include_pagedown(converter_js=url_for('static', filename='dist/js/md/converter.min.js'), 
+                          sanitizer_js=url_for('static', filename='dist/js/md/sanitizer.min.js')) }}
+
+You can also pass your own Markdown Sanitizer and Converter files to the `include_pagedown()` function, incase you have them hosted in your own CDN or even in your app's `static` directory. The example below uses the help of the `url_for` function, but you can pass the absolute path directly:
+
+    <html>
+    <head>
+    {{ pagedown.include_pagedown(converter_js=url_for('static', filename='dist/js/md/converter.min.js'), 
+                                 sanitizer_js=url_for('static', filename='dist/js/md/sanitizer.min.js')) }}
+    </head>
+    <body>
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            {{ form.pagedown(rows=10) }}
+            {{ form.submit }}
+        </form>
+    </body>
+    </html>
+
 The Javascript classes are imported from a CDN, there are no static files that need to be served by the application. If the request is secure then the Javascript files are imported from an https:// URL to match.
 
 To help adding specific CSS styling the `<textarea>` element has class `flask-pagedown-input` and the preview `<div>` has class `flask-pagedown-preview`.

--- a/README.md
+++ b/README.md
@@ -61,29 +61,13 @@ Finally, the template needs the support Javascript code added, by calling `paged
 
 The Javascript classes are imported from a CDN, there are no static files that need to be served by the application. If the request is secure then the Javascript files are imported from an https:// URL to match.
 
-Alternatively, you can also pass your own Markdown Sanitizer and Converter files to the `include_pagedown()` function, incase you have them hosted in your own CDN or even in your app's `static` directory. The example below uses the help of the `url_for` function, but you can pass the absolute path directly:
-
-    <html>
-    <head>
-    {{ pagedown.include_pagedown(converter_js=url_for('static', filename='dist/js/md/converter.min.js'), 
-                                 sanitizer_js=url_for('static', filename='dist/js/md/sanitizer.min.js')) }}
-    </head>
-    <body>
-        <form method="POST">
-            {{ form.hidden_tag() }}
-            {{ form.pagedown(rows=10) }}
-            {{ form.submit }}
-        </form>
-    </body>
-    </html>
-
-Or, leaving `jinja` out of the equation entirely, you can simply include the Converter and Sanitizer files directly in the HTML page:
+Or, leaving `jinja` out of the equation entirely, you can simply include your Converter and Sanitizer files directly in the HTML page, peradventure you have them hosted locally or on your own CDN:
 
     <html>
     <head>
         <!-- Converter before Sanitizer -->
         <script type="text/javascript" src="https://mycdn/path/to/converter.min.js"></script>
-        <script type="text/javascript" src="https://mycdn/path/to/sanitizer.min.js""></script>
+        <script type="text/javascript" src="https://mycdn/path/to/sanitizer.min.js"></script>
     </head>
     <body>
         <form method="POST">

--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ Alternatively, you can also pass your own Markdown Sanitizer and Converter files
     </body>
     </html>
 
+Or, leaving `jinja` out of the equation entirely, you can simply include the Converter and Sanitizer files directly in the HTML page:
+
+    <html>
+    <head>
+        <!-- Converter before Sanitizer -->
+        <script type="text/javascript" src="https://mycdn/path/to/converter.min.js"></script>
+        <script type="text/javascript" src="https://mycdn/path/to/sanitizer.min.js""></script>
+    </head>
+    <body>
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            {{ form.pagedown(rows=10) }}
+            {{ form.submit }}
+        </form>
+    </body>
+    </html>
+
 To help adding specific CSS styling the `<textarea>` element has class `flask-pagedown-input` and the preview `<div>` has class `flask-pagedown-preview`.
 
 With the template above, the preview area is created by the extension right below the input text area. For greater control, it is also possible to render the input and preview areas on different parts of the page. The following example shows how to render the preview area above the input area:

--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ Finally, the template needs the support Javascript code added, by calling `paged
     </body>
     </html>
 
-        {{ pagedown.include_pagedown(converter_js=url_for('static', filename='dist/js/md/converter.min.js'), 
-                          sanitizer_js=url_for('static', filename='dist/js/md/sanitizer.min.js')) }}
+The Javascript classes are imported from a CDN, there are no static files that need to be served by the application. If the request is secure then the Javascript files are imported from an https:// URL to match.
 
-You can also pass your own Markdown Sanitizer and Converter files to the `include_pagedown()` function, incase you have them hosted in your own CDN or even in your app's `static` directory. The example below uses the help of the `url_for` function, but you can pass the absolute path directly:
+Alternatively, you can also pass your own Markdown Sanitizer and Converter files to the `include_pagedown()` function, incase you have them hosted in your own CDN or even in your app's `static` directory. The example below uses the help of the `url_for` function, but you can pass the absolute path directly:
 
     <html>
     <head>
@@ -77,8 +76,6 @@ You can also pass your own Markdown Sanitizer and Converter files to the `includ
         </form>
     </body>
     </html>
-
-The Javascript classes are imported from a CDN, there are no static files that need to be served by the application. If the request is secure then the Javascript files are imported from an https:// URL to match.
 
 To help adding specific CSS styling the `<textarea>` element has class `flask-pagedown-input` and the preview `<div>` has class `flask-pagedown-preview`.
 

--- a/flask_pagedown/__init__.py
+++ b/flask_pagedown/__init__.py
@@ -3,14 +3,32 @@ from flask import current_app
 
 
 class _pagedown(object):
-    def include_pagedown(self):
-        return Markup('''
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.min.js"></script>
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Sanitizer.min.js"></script>
-''')
+    # Default MD urls
+    CONVERTER_JS_URL = "//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.min.js"
+    SANITIZER_JS_URL = "//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Sanitizer.min.js"
 
-    def html_head(self):
-        return self.include_pagedown()
+    def include_pagedown(self, converter_js=None, sanitizer_js=None):
+        """
+        Includes required markdown files in the page
+
+        :param str converter_js: Full path to the converter.js file
+        :param str sanitizer_js: Full path to the sanitizer.js file
+        """
+
+        # If path wasn't passed
+        if converter_js is None:
+            converter_js = self.__class__.CONVERTER_JS_URL
+
+        # If path wasn't passed
+        if sanitizer_js is None:
+            sanitizer_js = self.__class__.SANITIZER_JS_URL
+
+        return Markup('''
+                    <script type="text/javascript" src={0}></script>
+                    <script type="text/javascript" src={1}></script>
+                    '''.format(converter_js, sanitizer_js))
+
+        return self.include_pagedown(converter_js, sanitizer_js)
 
 
 class PageDown(object):

--- a/flask_pagedown/__init__.py
+++ b/flask_pagedown/__init__.py
@@ -3,30 +3,11 @@ from flask import current_app
 
 
 class _pagedown(object):
-    # Default MD urls
-    CONVERTER_JS_URL = "//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.min.js"
-    SANITIZER_JS_URL = "//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Sanitizer.min.js"
-
-    def include_pagedown(self, converter_js=None, sanitizer_js=None):
-        """
-        Includes required markdown files in the page
-
-        :param str converter_js: Full path to the converter.js file
-        :param str sanitizer_js: Full path to the sanitizer.js file
-        """
-
-        # If path wasn't passed
-        if converter_js is None:
-            converter_js = self.__class__.CONVERTER_JS_URL
-
-        # If path wasn't passed
-        if sanitizer_js is None:
-            sanitizer_js = self.__class__.SANITIZER_JS_URL
-
+    def include_pagedown(self):
         return Markup('''
-                    <script type="text/javascript" src={0}></script>
-                    <script type="text/javascript" src={1}></script>
-                    '''.format(converter_js, sanitizer_js))
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Sanitizer.min.js"></script>
+''')
 
     def html_head(self):
         return self.include_pagedown()

--- a/flask_pagedown/__init__.py
+++ b/flask_pagedown/__init__.py
@@ -28,6 +28,7 @@ class _pagedown(object):
                     <script type="text/javascript" src={1}></script>
                     '''.format(converter_js, sanitizer_js))
 
+    def html_head(self):
         return self.include_pagedown()
 
 

--- a/flask_pagedown/__init__.py
+++ b/flask_pagedown/__init__.py
@@ -28,7 +28,7 @@ class _pagedown(object):
                     <script type="text/javascript" src={1}></script>
                     '''.format(converter_js, sanitizer_js))
 
-        return self.include_pagedown(converter_js, sanitizer_js)
+        return self.include_pagedown()
 
 
 class PageDown(object):


### PR DESCRIPTION
Markdown files are hosted in a CDN. I want the option to load them from the app's `static` directory or an alternative CDN.
