### PR TITLE
Fix deprecation warnings by using markupsafe.Markup

### DIFF
--- a/flask_pagedown/__init__.py
+++ b/flask_pagedown/__init__.py
@@ -1,4 +1,4 @@
-from jinja2 import Markup
+from markupsafe import Markup
 from flask import current_app
 
 

--- a/flask_pagedown/widgets.py
+++ b/flask_pagedown/widgets.py
@@ -1,4 +1,4 @@
-from wtforms.widgets import HTMLString, TextArea
+from wtforms.widgets import TextArea
 from markupsafe import Markup
 
 pagedown_pre_html = '<div class="flask-pagedown">'
@@ -45,4 +45,4 @@ class PageDown(TextArea):
                 class_=' '.join(class_), **kwargs) + Markup(pagedown_post_html)
         if show_preview:
             html += Markup(preview_html % {'field': field.name})
-        return HTMLString(html)
+        return Markup(html)


### PR DESCRIPTION
Hi,

While working on a project using Flask-PageDown, I hit the following deprecation warnings while testing.


```
python3.7/site-packages/flask_pagedown/__init__.py:11: DeprecationWarning: 'jinja2.Markup' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.
  
python3.7/site-packages/flask_pagedown/widgets.py:55: DeprecationWarning: 'HTMLString' will be removed in WTForms 3.0. Use 'markupsafe.Markup' instead.
  return HTMLString(html)
```

I've made the updates suggested by the warnings. As for testing, I made these same changes in my project. The warnings are gone and everything appears to be working as expected.
